### PR TITLE
Make ContextSensitiveWeakHashMap work as normal weakhashmap when thread context not exists

### DIFF
--- a/src/main/java/org/commonjava/cdi/util/weft/ContextSensitiveWeakHashMap.java
+++ b/src/main/java/org/commonjava/cdi/util/weft/ContextSensitiveWeakHashMap.java
@@ -71,10 +71,6 @@ public class ContextSensitiveWeakHashMap<K, V>
 
             ctx.registerFinalizer( finalizer ); // register finalizer if not present
         }
-        else
-        {
-            throw new IllegalStateException( "Context Not Found" );
-        }
 
         return ret;
     }


### PR DESCRIPTION
Make it a bit less sensitive to the context.