### PR TITLE
Add load reporting to wrapper executor service and some logging in Locker

### DIFF
--- a/src/main/java/org/commonjava/cdi/util/weft/ExecutorProvider.java
+++ b/src/main/java/org/commonjava/cdi/util/weft/ExecutorProvider.java
@@ -21,7 +21,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
@@ -147,7 +146,7 @@ public class ExecutorProvider
         ExecutorService service = services.get( key );
         if ( service == null )
         {
-            final ThreadFactory fac = new NamedThreadFactory( name, daemon, priority );
+            final WeftThreadFactory fac = new WeftThreadFactory( name, daemon, priority );
 
             if ( scheduled )
             {
@@ -174,7 +173,7 @@ public class ExecutorProvider
                 registerMetrics( metricRegistry, metricPrefix, (ThreadPoolExecutor) service );
             }
 
-            service = new ContextSensitiveExecutorService( service, metricRegistry, metricPrefix );
+            service = new WeftExecutorService( service, threadCount, metricRegistry, metricPrefix );
 
             // TODO: Wrapper ThreadPoolExecutor that wraps Runnables to store/copy MDC when it gets created/started.
 

--- a/src/main/java/org/commonjava/cdi/util/weft/Locker.java
+++ b/src/main/java/org/commonjava/cdi/util/weft/Locker.java
@@ -93,14 +93,18 @@ public class Locker<K>
             Boolean locked = false;
             try
             {
+                logger.debug( "Locking on: {} with timeout seconds: {}", key, timeoutSeconds );
                 locked = lock.tryLock( timeoutSeconds, TimeUnit.SECONDS );
                 if ( locked )
                 {
+                    logger.debug( "Applying function locked with: {}", key );
                     return function.apply( key );
                 }
                 else
                 {
+                    logger.debug( "Lock failed for key: {}", key );
                     retry = lockFailedFunction.apply( key, lock );
+                    logger.debug( "Retry lock on: {}? {}", key, retry );
                 }
             }
             catch ( InterruptedException e )
@@ -109,14 +113,17 @@ public class Locker<K>
             }
             finally
             {
+                logger.debug( "Done, checking whether unlock needed for: {}", key );
                 if ( locked )
                 {
+                    logger.debug( "Unlocking key: {}", key );
                     lock.unlock();
                 }
             }
         }
         while ( retry == Boolean.TRUE );
 
+        logger.debug( "No retries, return null for locked operation on key: {}", key );
         return null;
     }
 

--- a/src/main/java/org/commonjava/cdi/util/weft/ThreadContext.java
+++ b/src/main/java/org/commonjava/cdi/util/weft/ThreadContext.java
@@ -32,7 +32,7 @@ import java.util.function.Function;
 
 /**
  * Effectively a multi-threaded implementation of ThreadLocal, where threads can pass on context to one another starting
- * with some "top" thread, and traversing to each "child" thread started via a {@link ContextSensitiveExecutorService}
+ * with some "top" thread, and traversing to each "child" thread started via a {@link WeftExecutorService}
  * instance, as is injected by Weft's @{@link WeftManaged} annotation.
  *
  * This {@link ThreadContext} keeps a count of the number of threads referencing it, and can run finalization logic

--- a/src/main/java/org/commonjava/cdi/util/weft/WeftThreadFactory.java
+++ b/src/main/java/org/commonjava/cdi/util/weft/WeftThreadFactory.java
@@ -17,7 +17,7 @@ package org.commonjava.cdi.util.weft;
 
 import java.util.concurrent.ThreadFactory;
 
-public class NamedThreadFactory
+public class WeftThreadFactory
     implements ThreadFactory
 {
 
@@ -31,7 +31,7 @@ public class NamedThreadFactory
 
     private final int priority;
 
-    public NamedThreadFactory( final String name, final boolean daemon, final int priority )
+    public WeftThreadFactory( final String name, final boolean daemon, final int priority )
     {
         this.ccl = Thread.currentThread()
                          .getContextClassLoader();
@@ -51,5 +51,4 @@ public class NamedThreadFactory
 
         return t;
     }
-
 }


### PR DESCRIPTION
Reporting will allow us to apply back-pressure on incoming calls when parts of the system are overloaded.