### PR TITLE
helper completion service that provides a mechanism for draining the service after loading it up

### DIFF
--- a/src/main/java/org/commonjava/cdi/util/weft/DrainingExecutorCompletionService.java
+++ b/src/main/java/org/commonjava/cdi/util/weft/DrainingExecutorCompletionService.java
@@ -1,0 +1,83 @@
+package org.commonjava.cdi.util.weft;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+public class DrainingExecutorCompletionService<T>
+{
+    private final ExecutorCompletionService<T> service;
+
+    private final AtomicInteger count = new AtomicInteger( 0 );
+
+    public DrainingExecutorCompletionService( ExecutorService service )
+    {
+        this.service = new ExecutorCompletionService<>( service );
+    }
+
+    public void drain( Consumer<T> consumer )
+            throws InterruptedException, ExecutionException
+    {
+        while ( count.get() > 0 )
+        {
+            T item = take().get();
+            consumer.accept( item );
+        }
+    }
+
+    public int getCurrentCount()
+    {
+        return count.get();
+    }
+
+    public Future<T> submit( final Callable<T> task )
+    {
+        Future<T> item = service.submit( task );
+        count.incrementAndGet();
+        return item;
+    }
+
+    public Future<T> submit( final Runnable task, final T result )
+    {
+        Future<T> item = service.submit( task, result );
+        count.incrementAndGet();
+
+        return item;
+    }
+
+    public Future<T> take()
+            throws InterruptedException
+    {
+        Future<T> item = service.take();
+        count.decrementAndGet();
+        return item;
+    }
+
+    public Future<T> poll()
+    {
+        Future<T> item = service.poll();
+        if ( item != null )
+        {
+            count.decrementAndGet();
+        }
+
+        return item;
+    }
+
+    public Future<T> poll( final long timeout, final TimeUnit unit )
+            throws InterruptedException
+    {
+        Future<T> item = service.poll( timeout, unit );
+        if ( item != null )
+        {
+            count.decrementAndGet();
+        }
+
+        return item;
+    }
+}


### PR DESCRIPTION
We have a lot of cases where we need to do time-consuming processing of a potentially large number of items, which can be processed in parallel. After loading up the completion service, you can apply a consumer to drain out completed tasks. This provides an easy way to process results of parallel actions without even having to know the size of the processing batch up front.