### PR TITLE
incorporate more info into the overload exception and make healthy rating loadSensitive

### DIFF
--- a/src/main/java/org/commonjava/cdi/util/weft/PoolWeftExecutorService.java
+++ b/src/main/java/org/commonjava/cdi/util/weft/PoolWeftExecutorService.java
@@ -83,7 +83,7 @@ public class PoolWeftExecutorService
     @Override
     public boolean isHealthy()
     {
-        return getLoadFactor() < maxLoadFactor;
+        return !loadSensitive || getLoadFactor() < maxLoadFactor;
     }
 
     @Override
@@ -139,7 +139,7 @@ public class PoolWeftExecutorService
     {
         if ( loadSensitive && !isHealthy() )
         {
-            throw new PoolOverloadException( getName(), getLoadFactor(), getCurrentLoad(), getThreadCount() );
+            throw new PoolOverloadException( getName(), getLoadFactor(), getCurrentLoad(), maxLoadFactor, getThreadCount() );
         }
     }
     

--- a/src/main/java/org/commonjava/cdi/util/weft/WeftPoolBoy.java
+++ b/src/main/java/org/commonjava/cdi/util/weft/WeftPoolBoy.java
@@ -11,8 +11,6 @@ import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Instance;
-import javax.enterprise.inject.UnsatisfiedResolutionException;
-import javax.enterprise.inject.spi.CDI;
 import javax.inject.Inject;
 import java.util.Collections;
 import java.util.HashMap;

--- a/src/main/java/org/commonjava/cdi/util/weft/exception/PoolOverloadException.java
+++ b/src/main/java/org/commonjava/cdi/util/weft/exception/PoolOverloadException.java
@@ -3,25 +3,52 @@ package org.commonjava.cdi.util.weft.exception;
 public class PoolOverloadException
                 extends RuntimeException
 {
-    final String poolName;
+    private final String poolName;
 
-    final double loadFactor;
+    private final double loadFactor;
 
-    final int currentLoad;
+    private final double currentLoad;
 
-    final int threadCount;
+    private Float maxLoadFactor;
 
-    public PoolOverloadException( String poolName, double loadFactor, int currentLoad, int threadCount )
+    private final int threadCount;
+
+    public PoolOverloadException( String poolName, double loadFactor, double currentLoad, final Float maxLoadFactor, int threadCount )
     {
-
         this.poolName = poolName;
         this.loadFactor = loadFactor;
         this.currentLoad = currentLoad;
+        this.maxLoadFactor = maxLoadFactor;
         this.threadCount = threadCount;
     }
 
+    public String getPoolName()
+    {
+        return poolName;
+    }
+
+    public double getLoadFactor()
+    {
+        return loadFactor;
+    }
+
+    public Float getMaxLoadFactor()
+    {
+        return maxLoadFactor;
+    }
+
+    public double getCurrentLoad()
+    {
+        return currentLoad;
+    }
+
+    public int getThreadCount()
+    {
+        return threadCount;
+    }
+
     @Override
-    public String toString()
+    public String getMessage()
     {
         return "PoolOverloadException{" + "poolName='" + poolName + '\'' + ", loadFactor=" + loadFactor
                         + ", currentLoad=" + currentLoad + ", threadCount=" + threadCount + '}';


### PR DESCRIPTION
isHealthy() will always return true until the pool is loadSensitive, then it takes the load factor into account.