### PR TITLE
Add default loadSensitive and align the usage as others

### DIFF
--- a/src/main/java/org/commonjava/cdi/util/weft/ExecutorConfig.java
+++ b/src/main/java/org/commonjava/cdi/util/weft/ExecutorConfig.java
@@ -28,6 +28,11 @@ import java.lang.annotation.Target;
 @Target( { METHOD, FIELD, PARAMETER, TYPE } )
 public @interface ExecutorConfig
 {
+    // to differentiate not specified and false/true
+    enum BooleanLiteral
+    {
+        NULL, TRUE, FALSE
+    }
 
     int threads() default 0;
 
@@ -39,6 +44,6 @@ public @interface ExecutorConfig
 
     boolean daemon() default true;
 
-    int loadSensitive() default -1; // -1 not specified, 0 false, 1 true
+    BooleanLiteral loadSensitive() default BooleanLiteral.NULL;
 
 }

--- a/src/main/java/org/commonjava/cdi/util/weft/ExecutorConfig.java
+++ b/src/main/java/org/commonjava/cdi/util/weft/ExecutorConfig.java
@@ -39,6 +39,6 @@ public @interface ExecutorConfig
 
     boolean daemon() default true;
 
-    boolean loadSensitive() default false;
+    int loadSensitive() default -1; // -1 not specified, 0 false, 1 true
 
 }

--- a/src/main/java/org/commonjava/cdi/util/weft/WeftPoolBoy.java
+++ b/src/main/java/org/commonjava/cdi/util/weft/WeftPoolBoy.java
@@ -129,12 +129,12 @@ public class WeftPoolBoy
             maxLoadFactor = ec.maxLoadFactor();
             daemon = ec.daemon();
 
-            int ls = ec.loadSensitive();
-            if ( ls == 0 )
+            ExecutorConfig.BooleanLiteral ls = ec.loadSensitive();
+            if ( ls == ExecutorConfig.BooleanLiteral.FALSE )
             {
                 loadSensitive = false;
             }
-            else if ( ls == 1 )
+            else if ( ls == ExecutorConfig.BooleanLiteral.TRUE )
             {
                 loadSensitive = true;
             }

--- a/src/main/java/org/commonjava/cdi/util/weft/WeftPoolBoy.java
+++ b/src/main/java/org/commonjava/cdi/util/weft/WeftPoolBoy.java
@@ -114,9 +114,9 @@ public class WeftPoolBoy
         Integer threadCount = 0;
         Integer priority = null;
         Float maxLoadFactor = null;
+        Boolean loadSensitive = null;
 
         boolean daemon = true;
-        boolean loadSensitive = false;
 
         // TODO: This may cause counter-intuitive sharing of thread pools for un-annotated injections...
         String name = "weft-unannotated";
@@ -128,7 +128,16 @@ public class WeftPoolBoy
             priority = ec.priority();
             maxLoadFactor = ec.maxLoadFactor();
             daemon = ec.daemon();
-            loadSensitive = ec.loadSensitive();
+
+            int ls = ec.loadSensitive();
+            if ( ls == 0 )
+            {
+                loadSensitive = false;
+            }
+            else if ( ls == 1 )
+            {
+                loadSensitive = true;
+            }
         }
 
         final String key = name + ":" + ( scheduled ? "scheduled" : "" );

--- a/src/main/java/org/commonjava/cdi/util/weft/config/DefaultWeftConfig.java
+++ b/src/main/java/org/commonjava/cdi/util/weft/config/DefaultWeftConfig.java
@@ -46,6 +46,8 @@ public class DefaultWeftConfig
 
     private final Map<String, Boolean> loadSensitivePools = new HashMap<>();
 
+    private boolean defaultLoadSensitive;
+
     private int defaultThreads = DEFAULT_THREADS;
 
     private int defaultPriority = DEFAULT_PRIORITY;
@@ -87,6 +89,12 @@ public class DefaultWeftConfig
     public DefaultWeftConfig configureDefaultMaxLoadFactor( final float maxLoadFactor )
     {
         this.defaultMaxLoadFactor = maxLoadFactor;
+        return this;
+    }
+
+    public DefaultWeftConfig configureDefaultLoadSensitive( final boolean defaultLoadSensitive )
+    {
+        this.defaultLoadSensitive = defaultLoadSensitive;
         return this;
     }
 
@@ -240,14 +248,15 @@ public class DefaultWeftConfig
     }
 
     @Override
-    public boolean isLoadSensitive( final String poolName, final boolean defaultLoadSensitive )
+    public boolean isLoadSensitive( final String poolName, final Boolean defaultValue )
     {
-        Boolean v = loadSensitivePools.get( poolName );
-        if ( v == null )
-        {
-            return defaultLoadSensitive;
-        }
-        return v;
+        return getWithDefaultAndFailover( poolName, defaultValue, isDefaultLoadSensitive() );
+    }
+
+    @Override
+    public boolean isDefaultLoadSensitive()
+    {
+        return defaultLoadSensitive;
     }
 
     @Override
@@ -273,6 +282,17 @@ public class DefaultWeftConfig
         if ( v == null )
         {
             return defaultValue == null  || defaultValue == 0 ? failover : defaultValue;
+        }
+
+        return v;
+    }
+
+    private boolean getWithDefaultAndFailover( String poolName, Boolean defaultValue, Boolean failover )
+    {
+        Boolean v = loadSensitivePools.get( poolName );
+        if ( v == null )
+        {
+            return defaultValue == null ? failover : defaultValue;
         }
 
         return v;

--- a/src/main/java/org/commonjava/cdi/util/weft/config/WeftConfig.java
+++ b/src/main/java/org/commonjava/cdi/util/weft/config/WeftConfig.java
@@ -42,7 +42,9 @@ public interface WeftConfig
 
     float getDefaultMaxLoadFactor();
 
-    boolean isLoadSensitive( String poolName, boolean defaultLoadSensitive );
+    boolean isLoadSensitive( String poolName, Boolean defaultLoadSensitive );
+
+    boolean isDefaultLoadSensitive();
 
     String getNodePrefix(); // for cluster env
 


### PR DESCRIPTION
I align the way of configuring loadSensitive same as others. Because Java annotation methods can only return primitive types, I can not make use of Boolean. I have to do a trick as:
int loadSensitive() default -1; // -1 not specified, 0 false, 1 true
to differentiate the false and null. 
Please review. 