### PR TITLE
add SignallingLocker and update Locker with stale sweeper

### DIFF
--- a/src/main/java/org/commonjava/cdi/util/weft/Locker.java
+++ b/src/main/java/org/commonjava/cdi/util/weft/Locker.java
@@ -38,12 +38,12 @@ public class Locker<K>
 
     public Locker()
     {
-        this( Collections.synchronizedMap( new ContextSensitiveWeakHashMap<>() ), DEFAULT_SWEEP_MS );
+        this( new ContextSensitiveWeakHashMap<>(), DEFAULT_SWEEP_MS );
     }
 
     public Locker( long sweepStaleLocks )
     {
-        this( Collections.synchronizedMap( new ContextSensitiveWeakHashMap<>() ), sweepStaleLocks );
+        this( new ContextSensitiveWeakHashMap<>(), sweepStaleLocks );
     }
 
     public Locker( Map<K, ReentrantLock> locks, long staleSweepMillis )

--- a/src/main/java/org/commonjava/cdi/util/weft/SignallingLock.java
+++ b/src/main/java/org/commonjava/cdi/util/weft/SignallingLock.java
@@ -1,0 +1,207 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.cdi.util.weft;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+
+public class SignallingLock
+{
+    private ReentrantLock lock = new ReentrantLock();
+
+    private final Condition changed = lock.newCondition();
+
+    private String locker;
+
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    public boolean lock()
+            throws InterruptedException
+    {
+        logger.trace( "Locking: {} for: {}", this, Thread.currentThread().getName() );
+
+        lock.lockInterruptibly();
+        locker = Thread.currentThread().getName();
+
+        logger.trace( "Lock established." );
+        return true;
+    }
+
+    public boolean isStale()
+    {
+        synchronized ( lock )
+        {
+            return !lock.isLocked() && !lock.hasQueuedThreads();
+        }
+    }
+
+    public void unlock()
+    {
+        synchronized ( lock )
+        {
+            if ( lock.isHeldByCurrentThread() )
+            {
+                logger.trace( "Locking: {}", this );
+
+                changed.signal();
+                lock.unlock();
+                locker = null;
+
+                logger.trace( "Locked released" );
+            }
+        }
+    }
+
+    public void await( long timeoutMs )
+            throws InterruptedException
+    {
+        if ( lock.isLocked() )
+        {
+            logger.trace( "Waiting for unlock of: {}", this );
+            changed.await( timeoutMs, TimeUnit.MILLISECONDS );
+        }
+    }
+
+    public void signal()
+    {
+        if ( lock.isHeldByCurrentThread() )
+        {
+            logger.trace( "Signal from: {} in lock of: {}", Thread.currentThread().getName(), this );
+            changed.signal();
+        }
+    }
+
+    public void await()
+            throws InterruptedException
+    {
+        if ( lock.isLocked() )
+        {
+            logger.trace( "Waiting for unlock of: {}", this );
+            changed.await();
+        }
+    }
+
+    public boolean await( final long l, final TimeUnit timeUnit )
+            throws InterruptedException
+    {
+        if ( lock.isLocked() )
+        {
+            logger.trace( "Waiting for unlock of: {}", this );
+
+            return changed.await( l, timeUnit );
+        }
+
+        return true;
+    }
+
+    public void signalAll()
+    {
+        if ( lock.isHeldByCurrentThread() )
+        {
+            logger.trace( "Signal from: {} in lock of: {}", Thread.currentThread().getName(), this );
+            changed.signalAll();
+        }
+    }
+
+    public void lockInterruptibly()
+            throws InterruptedException
+    {
+        logger.trace( "Locking: {} for: {}", this, Thread.currentThread().getName() );
+
+        lock.lockInterruptibly();
+        locker = Thread.currentThread().getName();
+
+        logger.trace( "Lock established." );
+    }
+
+    public boolean tryLock()
+    {
+        boolean locked = lock.tryLock();
+        if ( locked )
+        {
+            locker = Thread.currentThread().getName();
+        }
+
+        return locked;
+    }
+
+    public boolean tryLock( final long timeout, final TimeUnit unit )
+            throws InterruptedException
+    {
+        boolean locked = lock.tryLock( timeout, unit );
+        if ( locked )
+        {
+            locker = Thread.currentThread().getName();
+        }
+
+        return locked;
+    }
+
+    public int getHoldCount()
+    {
+        return lock.getHoldCount();
+    }
+
+    public boolean isHeldByCurrentThread()
+    {
+        return lock.isHeldByCurrentThread();
+    }
+
+    public boolean isLocked()
+    {
+        return lock.isLocked();
+    }
+
+    public boolean isFair()
+    {
+        return lock.isFair();
+    }
+
+    public boolean hasQueuedThreads()
+    {
+        return lock.hasQueuedThreads();
+    }
+
+    public boolean hasQueuedThread( final Thread thread )
+    {
+        return lock.hasQueuedThread( thread );
+    }
+
+    public int getQueueLength()
+    {
+        return lock.getQueueLength();
+    }
+
+    public boolean hasWaiters( final Condition condition )
+    {
+        return lock.hasWaiters( condition );
+    }
+
+    public int getWaitQueueLength( final Condition condition )
+    {
+        return lock.getWaitQueueLength( condition );
+    }
+
+    public String getLocker()
+    {
+        return locker;
+    }
+}

--- a/src/main/java/org/commonjava/cdi/util/weft/SignallingLockOperation.java
+++ b/src/main/java/org/commonjava/cdi/util/weft/SignallingLockOperation.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.cdi.util.weft;
+
+@FunctionalInterface
+public interface SignallingLockOperation<K, S, T>
+{
+    T apply( K key, S state, SignallingLock lock );
+}

--- a/src/test/java/org/commonjava/cdi/util/weft/SignallingLockerTest.java
+++ b/src/test/java/org/commonjava/cdi/util/weft/SignallingLockerTest.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.cdi.util.weft;
+
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class SignallingLockerTest
+{
+    private SignallingLocker<String> locker = new SignallingLocker<>( 100 );
+    private final long timeout = 100;
+
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    @Test
+    public void sweepStaleLocks()
+            throws Exception
+    {
+        String key = "foo";
+
+        ExecutorService exec = Executors.newFixedThreadPool( 2 );
+
+        AtomicBoolean race = new AtomicBoolean( false );
+
+        Map<String, SignallingLock> locks = new ConcurrentHashMap<>();
+
+        ExecutorCompletionService<Void> service = new ExecutorCompletionService<>( exec );
+
+        service.submit( op( "1", key, race, locks ) );
+        service.submit( op( "2", key, race, locks ) );
+
+        race.set( true );
+
+        for(int i=0; i<2; i++)
+        {
+            service.take().get();
+        }
+
+        logger.info( "Waiting for sweep" );
+
+        Thread.sleep( 200 );
+
+        logger.info( "Retrying third lock" );
+
+        op( "3", key, race, locks ).call();
+
+        logger.info( "Locks: \n\n{}\n\n", locks );
+
+        assertThat( "threaded locks should be the same instance", locks.get("1") == locks.get("2"));
+        assertThat( "threaded locks should NOT be the same as the third lock instance", locks.get("1") != locks.get("3)"));
+    }
+
+    private Callable<Void> op( String id, String key, AtomicBoolean race, Map<String, SignallingLock> locks )
+    {
+        return () -> {
+            // loop until we're ready.
+            while ( !race.get() )
+            {
+                logger.info( "{} waiting.", id );
+                try
+                {
+                    Thread.sleep( 10 );
+                }
+                catch ( InterruptedException e )
+                {
+                    e.printStackTrace();
+                }
+            }
+
+            locker.lockAnd( key, ( k, lock ) -> {
+                logger.info( "{} locked and running.", id );
+                locks.put( id, lock );
+
+                try
+                {
+                    Thread.sleep( timeout );
+                }
+                catch ( InterruptedException e )
+                {
+                    e.printStackTrace();
+                }
+
+                return null;
+            } );
+
+            return null;
+        };
+    }
+}


### PR DESCRIPTION
SignallingLocker provides a variant of Locker using a Condition option wrapped together
with a ReentrantLock into SignallingLock, to allow threads to communicate via a lock.
This is similar to the old Object.wait() / Object.notify() behavior, but scoped to
the lock.