### PR TITLE
synchronize process of creating temp map for iteration during stale lock sweep

### DIFF
--- a/src/main/java/org/commonjava/cdi/util/weft/Locker.java
+++ b/src/main/java/org/commonjava/cdi/util/weft/Locker.java
@@ -154,7 +154,13 @@ public class Locker<K>
         @Override
         public void run()
         {
-            new HashMap<>( locks ).forEach( ( key, lock)->{
+            Map<K, ReentrantLock> toScan;
+            synchronized ( locks )
+            {
+                toScan = new HashMap<>( locks );
+            }
+
+            toScan.forEach( ( key, lock)->{
                 if ( isStale(lock) )
                 {
                     locks.remove( key );

--- a/src/main/java/org/commonjava/cdi/util/weft/SignallingLocker.java
+++ b/src/main/java/org/commonjava/cdi/util/weft/SignallingLocker.java
@@ -63,21 +63,6 @@ public class SignallingLocker<K>
         this.timer.scheduleAtFixedRate( new SweepStaleTask(), staleSweepMillis, staleSweepMillis );
     }
 
-    private final class SweepStaleTask
-            extends TimerTask
-    {
-        @Override
-        public void run()
-        {
-            new HashMap<>( locks ).forEach( ( key, lock )-> {
-                if ( lock.isStale() )
-                {
-                    locks.remove( key );
-                }
-            } );
-        }
-    }
-
     /**
      * Remove lock proactively
      */
@@ -226,4 +211,24 @@ public class SignallingLocker<K>
         return null;
     }
 
+    private final class SweepStaleTask
+            extends TimerTask
+    {
+        @Override
+        public void run()
+        {
+            Map<K, SignallingLock> toScan;
+            synchronized ( locks )
+            {
+                toScan = new HashMap<>( locks );
+            }
+
+            toScan.forEach( ( key, lock)->{
+                if ( lock.isStale() )
+                {
+                    locks.remove( key );
+                }
+            } );
+        }
+    }
 }


### PR DESCRIPTION
It looks like we're getting ConcurrentModificationException sometimes when the sweeper thread is creating a temporary copy of the lock map for iterating. I've synchronized that creation using the original map as the locking object.