### PR TITLE
Adding concept of a thread contextualizer

### DIFF
--- a/src/main/java/org/commonjava/cdi/util/weft/ThreadContext.java
+++ b/src/main/java/org/commonjava/cdi/util/weft/ThreadContext.java
@@ -21,6 +21,8 @@ import org.slf4j.MDC;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;

--- a/src/main/java/org/commonjava/cdi/util/weft/ThreadContextualizer.java
+++ b/src/main/java/org/commonjava/cdi/util/weft/ThreadContextualizer.java
@@ -1,0 +1,12 @@
+package org.commonjava.cdi.util.weft;
+
+public interface ThreadContextualizer
+{
+    String getId();
+
+    Object extractCurrentContext();
+
+    void setChildContext( Object parentContext );
+
+    void clearContext();
+}

--- a/src/main/java/org/commonjava/cdi/util/weft/WeftPoolBoy.java
+++ b/src/main/java/org/commonjava/cdi/util/weft/WeftPoolBoy.java
@@ -57,6 +57,9 @@ public class WeftPoolBoy
     @Inject
     private Instance<HealthCheckRegistry> healthCheckRegistryInstance;
 
+    @Inject
+    private Instance<ThreadContextualizer> contextualizers;
+
     private HealthCheckRegistry healthCheckRegistry;
 
     protected WeftPoolBoy(){}
@@ -202,7 +205,7 @@ public class WeftPoolBoy
             String metricPrefix = name( config.getNodePrefix(), "weft.ThreadPoolExecutor", name );
 
             service = new PoolWeftExecutorService( name, svc, threadCount, maxLoadFactor, loadSensitive, metricRegistry,
-                                                   metricPrefix );
+                                                   metricPrefix, contextualizers );
 
             // TODO: Wrapper ThreadPoolExecutor that wraps Runnables to store/copy MDC when it gets created/started.
 
@@ -222,7 +225,6 @@ public class WeftPoolBoy
             metricRegistry.register( name( prefix, "activeThreads" ), (Gauge<Integer>) () -> pool.getActiveCount() );
             metricRegistry.register( name( prefix, "loadFactor" ), (Gauge<Double>) () -> pool.getLoadFactor() );
             metricRegistry.register( name( prefix, "currentLoad" ), (Gauge<Long>) () -> pool.getCurrentLoad() );
-            metricRegistry.register( name( prefix, "queueSize" ), (Gauge<Long>) () -> pool.getTaskCount() );
         }
 
         if ( healthCheckRegistry != null )

--- a/src/test/java/org/commonjava/cdi/util/weft/MDCTest.java
+++ b/src/test/java/org/commonjava/cdi/util/weft/MDCTest.java
@@ -75,7 +75,7 @@ public class MDCTest {
         MDCTest client = container.instance().select(MDCTest.class).get();
 
         Logger logger = LoggerFactory.getLogger( getClass() );
-        MDC.put("requestID", "master-indy-01");
+        MDC.put( "requestID", "master-indy-01");
 
         ThreadContext ctx = ThreadContext.getContext(true);
 


### PR DESCRIPTION
ThreadContextualizer enables an application to apply custom extraction / initialization logic before a Runnable / Callable starts in a thread pool. Common actions here will be extracting a value from a ThreadLocal, then setting it in the same ThreadLocal when the Runnable/Callable starts, which will bridge the value across threads. When the Runnable/Callable completes, the value is cleared from the pooled thread's context to cleanup any memory consumption that might get lost in the pool.

This is specifically useful for Honeycomb event reporting, where the Honeycomb API binds the parent span to a ThreadLocal, and threaded calls get lost in the trace. Using a ThreadContextualizer, we're able to work around this limitation and store the parent span in our own ThreadLocal for bridging to associated thread executions.