### PR TITLE
Return zero to enable a cached thread pool.

### DIFF
--- a/src/main/java/org/commonjava/cdi/util/weft/config/DefaultWeftConfig.java
+++ b/src/main/java/org/commonjava/cdi/util/weft/config/DefaultWeftConfig.java
@@ -270,7 +270,7 @@ public class DefaultWeftConfig
         final Integer v = config.get( poolName + suffix );
         if ( v == null || v < 1 )
         {
-            return defaultValue == null  || defaultValue < 1 ? failover : defaultValue;
+            return defaultValue == null || defaultValue < 0 ? failover : defaultValue;
         }
 
         return v;


### PR DESCRIPTION
This PR solves the issue identified in #47 
 The change allows a 0 to be returned.