### PR TITLE
Add api to weftboy to get executorservice programmatically

### DIFF
--- a/src/main/java/org/commonjava/cdi/util/weft/WeftPoolBoy.java
+++ b/src/main/java/org/commonjava/cdi/util/weft/WeftPoolBoy.java
@@ -134,7 +134,7 @@ public class WeftPoolBoy
     /**
      * This method is used when using cdi @Inject.
      */
-    public WeftExecutorService getPool( final ExecutorConfig ec, final boolean scheduled )
+    public synchronized WeftExecutorService getPool( final ExecutorConfig ec, final boolean scheduled )
     {
         if ( ec != null )
         {
@@ -166,7 +166,7 @@ public class WeftPoolBoy
     /**
      * Get pool programmatically. The parameters can be overridden via configuration file. If no config, this will create thread pool as is.
      */
-    public WeftExecutorService getPool( String name, int threadCount, int priority, float maxLoadFactor,
+    public synchronized WeftExecutorService getPool( String name, int threadCount, int priority, float maxLoadFactor,
                                         boolean loadSensitive, boolean daemon, final boolean scheduled )
     {
 

--- a/src/main/java/org/commonjava/cdi/util/weft/WeftPoolBoy.java
+++ b/src/main/java/org/commonjava/cdi/util/weft/WeftPoolBoy.java
@@ -114,14 +114,22 @@ public class WeftPoolBoy
     }
 
     /**
-     * TODO: This may cause counter-intuitive sharing of thread pools for un-annotated injections...
+     * When we use cdi @Inject, the ec should always has name. The ec.name will override the dummy "weft-unannotated".
      */
     public synchronized WeftExecutorService getPool( final ExecutorConfig ec, final boolean scheduled )
     {
         return getPool( "weft-unannotated", ec, scheduled );
     }
 
-    public synchronized WeftExecutorService getPool( String name, final ExecutorConfig ec, final boolean scheduled )
+    /**
+     * Get pool programmatically. We can control it via configuration file. If no config, this will return a single threaded pool.
+     */
+    public synchronized WeftExecutorService getPool( final String name, final boolean scheduled )
+    {
+        return getPool( name, null, scheduled );
+    }
+
+    private WeftExecutorService getPool( String name, final ExecutorConfig ec, final boolean scheduled )
     {
         Integer threadCount = 0;
         Integer priority = null;

--- a/src/main/java/org/commonjava/cdi/util/weft/WeftPoolBoy.java
+++ b/src/main/java/org/commonjava/cdi/util/weft/WeftPoolBoy.java
@@ -113,7 +113,15 @@ public class WeftPoolBoy
         }
     }
 
+    /**
+     * TODO: This may cause counter-intuitive sharing of thread pools for un-annotated injections...
+     */
     public synchronized WeftExecutorService getPool( final ExecutorConfig ec, final boolean scheduled )
+    {
+        return getPool( "weft-unannotated", ec, scheduled );
+    }
+
+    public synchronized WeftExecutorService getPool( String name, final ExecutorConfig ec, final boolean scheduled )
     {
         Integer threadCount = 0;
         Integer priority = null;
@@ -121,9 +129,6 @@ public class WeftPoolBoy
         Boolean loadSensitive = null;
 
         boolean daemon = true;
-
-        // TODO: This may cause counter-intuitive sharing of thread pools for un-annotated injections...
-        String name = "weft-unannotated";
 
         if ( ec != null )
         {

--- a/src/main/java/org/commonjava/cdi/util/weft/config/DefaultWeftConfig.java
+++ b/src/main/java/org/commonjava/cdi/util/weft/config/DefaultWeftConfig.java
@@ -29,12 +29,11 @@ public class DefaultWeftConfig
 
     public static final String PRIORITY_SUFFIX = "p";
 
-    private static final int DEFAULT_THREADS = Runtime.getRuntime()
-                                                      .availableProcessors() * 2;
+    public static final int DEFAULT_THREADS = Runtime.getRuntime().availableProcessors() * 2;
 
-    private static final int DEFAULT_PRIORITY = 8;
+    public static final int DEFAULT_PRIORITY = 8;
 
-    private static final float DEFAULT_MAX_LOAD_FACTOR = 10.0f;
+    public static final float DEFAULT_MAX_LOAD_FACTOR = 10.0f;
 
     private boolean enabled = true;
 


### PR DESCRIPTION
This allows we get a weft managed pool on demand (not by @Inject). Sometimes, the pool needs to be constructed programmatically thus we need to pass a name. We can still control it in threadpool.conf.