### PR TITLE
Add dependencies for JDK11 to compile code.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,8 @@
     <plugin.jacoco.skip>false</plugin.jacoco.skip>
     <o11yphantVersion>1.0-SNAPSHOT</o11yphantVersion>
     <weldVersion>2.4.6.Final</weldVersion>
+    <activationVersion>1.2.0</activationVersion>
+    <annotationVersion>1.3.2</annotationVersion>
   </properties>
 
   <dependencyManagement>
@@ -60,6 +62,16 @@
         <groupId>org.commonjava.util</groupId>
         <artifactId>o11yphant-metrics-api</artifactId>
         <version>${o11yphantVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.activation</groupId>
+        <artifactId>javax.activation-api</artifactId>
+        <version>${activationVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.annotation</groupId>
+        <artifactId>javax.annotation-api</artifactId>
+        <version>${annotationVersion}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -101,6 +113,14 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.activation</groupId>
+      <artifactId>javax.activation-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
     </dependency>
   </dependencies>
   


### PR DESCRIPTION
 Adding this dependency should not affect compiling with JDK8.