### PR TITLE
Add javax.annotation to compile by jdk11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
     <plugin.jacoco.skip>false</plugin.jacoco.skip>
     <o11yphantVersion>1.0-SNAPSHOT</o11yphantVersion>
     <weldVersion>2.4.6.Final</weldVersion>
+    <annotationVersion>1.3.2</annotationVersion>
   </properties>
 
   <dependencyManagement>
@@ -60,6 +61,11 @@
         <groupId>org.commonjava.util</groupId>
         <artifactId>o11yphant-metrics-api</artifactId>
         <version>${o11yphantVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.annotation</groupId>
+        <artifactId>javax.annotation-api</artifactId>
+        <version>${annotationVersion}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -78,6 +84,10 @@
     <dependency>
       <groupId>javax.enterprise</groupId>
       <artifactId>cdi-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Fix "package javax.annotation does not exist" compile error on jdk11.
p.s. it seems we only need to adjust some dependencies to get java 8 project build on jdk11. This is one example of it.