### PR TITLE
Fix the waitForLock hang by unlocking it after successfully required the lock

### DIFF
--- a/src/main/java/org/commonjava/cdi/util/weft/Locker.java
+++ b/src/main/java/org/commonjava/cdi/util/weft/Locker.java
@@ -85,12 +85,19 @@ public class Locker<K>
         boolean waitingLocked = false;
         try
         {
-            //TODO: will let non-working threads wait here for seconds for the result of the working thread processing. Need to evaluate how long should wait here in future.
+            // Let non-working threads wait here for seconds for the result of the working thread processing. Need to evaluate how long should wait here in future.
             waitingLocked = lock.tryLock( timeoutSeconds, TimeUnit.SECONDS );
         }
         catch ( InterruptedException e )
         {
             logger.warn( "Thread interrupted by other threads for waiting processing result: {}", e.getMessage() );
+        }
+        finally
+        {
+            if ( lock.isHeldByCurrentThread() )
+            {
+                lock.unlock();
+            }
         }
 
         return waitingLocked;


### PR DESCRIPTION
Indy use it as below in MavenMetadataGenerator,
```
boolean mergingDone = mergerLocks.ifUnlocked( computeKey(group, toMergePath), p-> {
    logger.debug( "Start metadata generation for metadata file {} in group {}", path, group );
    ...
    return true;
}, (p,mergerLock)-> {
   logger.info("The metadata generation is still in process by another thread for the metadata file for this path {} in group {}, so block current thread to wait for result", ... );
   return mergerLocks.waitForLock( THREAD_WAITING_TIME_SECONDS, mergerLock );
} );
```

This is meant for the case when the first thread are generating the metadata, the second request wait for the result.
The problem is, when the second thread aquired the lock by waitForLock, it never unlock it. The following requests keep hitting the locked lock, and continue doing waitForLock and finally all of them timeout after 5 minutes. 

This dead lock occurred to the healthcheck requests (xom/xom/maven-metadata.xml). I saw all the healthchecks failed from August 26th 2021, 11:06:15.000 on stage. According to Grafana, from then on, Indy maven-download slowed down to 5 min (Normally it is about 40 ms). I suspect this is the cause of Indy hang. 
