### PR TITLE
Update web-commons to 29

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
       <dependency>
         <groupId>org.commonjava.boms</groupId>
         <artifactId>web-commons-bom</artifactId>
-        <version>29-SNAPSHOT</version>
+        <version>29</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
I found the Indy's release tool has a bug - weft released version 2.0 contains web-commons snapshot dependency but it passed the release. Not sure what happened. This pr update the web-commons version.